### PR TITLE
Added --hls option to livepeer stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,14 @@ You can also use the web interface to test out streaming. To do that, make sure 
 
 ### Transcoding
 
-Currently transcoding is an experimental feature.  Check out the [hls branch](https://github.com/livepeer/go-livepeer/tree/hls) for more informaiton.
+Currently transcoding is an experimental feature. An HLS output stream
+is available with its own unique streamID, which is placed into the
+console output. Try
+
+`livepeer --hls stream <HLS streamID>`
+
+to consume the HLS transcoded stream. Standby for more updates on
+using the network to transcode into multiple formats and bitrates.
 
 ## Metrics and monitoring
 


### PR DESCRIPTION
In order to request the HLS version. Just paste the HLS stream ID instead of the RTMP stream ID, and it will look at the --rtmp port + 7000. (Default is 1935, so you can omit the --rtmp flag if that's the node you're playing from.

Example: `livepeer --hls stream 68d45ccff04e7338273a4040cf0d12d6d4fbdab8023c2005536e912385245434520ef57c5da56c305511e9c0689ddced66a80417b3f0b4856123d391e8df9581`

Or `livepeer --rtmp 1936 --hls stream 68d45ccff04e7338273a4040cf0d12d6d4fbdab8023c2005536e912385245434520ef57c5da56c305511e9c0689ddced66a80417b3f0b4856123d391e8df9581`