### PR TITLE
fixing unsubscribe bug

### DIFF
--- a/livepeer/network/protocol.go
+++ b/livepeer/network/protocol.go
@@ -309,6 +309,7 @@ func (self *bzz) handle() error {
 		if req.Id == streaming.RequestStreamMsgID {
 			if strm == nil {
 				//Create new network stream?
+				glog.Infof("Cannot find stream %v locally, forwarding to the network.", concatedStreamID)
 				(*self.forwarder).Stream(string(concatedStreamID), self.remoteAddr.Addr, req.Format)
 				self.viz.LogRelay(string(concatedStreamID))
 			}

--- a/livepeer/streaming/streamer.go
+++ b/livepeer/streaming/streamer.go
@@ -4,15 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
-	"errors"
 	"fmt"
 	"math/rand"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
-	"github.com/kz26/m3u8"
 	lpmsStream "github.com/livepeer/lpms/stream"
 	"github.com/nareix/joy4/av"
 	"github.com/nareix/joy4/av/pubsub"
@@ -59,185 +56,38 @@ type HlsSegment struct {
 	Name string
 }
 
-// A stream represents one stream
-type Stream struct {
-	SrcVideoChan  chan *VideoChunk
-	DstVideoChan  chan *VideoChunk
-	M3U8Chan      chan []byte
-	HlsSegChan    chan HlsSegment
-	HlsSegNameMap map[string][]byte
-	M3U8          []byte
-	lastDstSeq    int64
-	ID            StreamID
-	CloseChan     chan bool
-}
-
-func (self *Stream) PutToDstVideoChan(chunk *VideoChunk) {
-	livepeerChunkInMeter.Mark(1)
-	//Put to the stream
-	if (chunk.HLSSegName != "") && (chunk.HLSSegData != nil) {
-		//Should kick out old segments when the map reaches a certain size.
-		self.HlsSegNameMap[chunk.HLSSegName] = chunk.HLSSegData
-	} else if chunk.M3U8 != nil {
-		self.M3U8 = chunk.M3U8
-	} else {
-		select {
-		case self.DstVideoChan <- chunk:
-			if self.lastDstSeq < chunk.Seq-1 {
-				glog.V(logger.Info).Infof("Chunk skipped at %d\n", chunk.Seq)
-				livepeerChunkSkipMeter.Mark(1)
-			}
-			self.lastDstSeq = chunk.Seq
-		default:
-		}
-	}
-}
-
-func (self *Stream) PutToSrcVideoChan(chunk *VideoChunk) {
-	select {
-	case self.SrcVideoChan <- chunk:
-	default:
-	}
-}
-
-func (self *Stream) GetFromDstVideoChan() *VideoChunk {
-	return <-self.DstVideoChan
-}
-
-func (self *Stream) GetFromSrcVideoChan() *VideoChunk {
-	return <-self.SrcVideoChan
-}
-
-func (self *Stream) WriteHeader(streams []av.CodecData) error {
-	glog.V(logger.Info).Infof("Write Header")
-	chunk := &VideoChunk{
-		ID:            DeliverStreamMsgID,
-		Seq:           0,
-		HeaderStreams: streams,
-		Packet:        av.Packet{},
-		M3U8:          nil,
-		HLSSegData:    nil,
-		HLSSegName:    "",
-	}
-	self.PutToSrcVideoChan(chunk)
-
-	return nil
-}
-
-func (self *Stream) WritePacket(pkt av.Packet) error {
-	chunk := &VideoChunk{
-		ID:            DeliverStreamMsgID,
-		Seq:           0,
-		HeaderStreams: nil,
-		Packet:        pkt,
-		M3U8:          nil,
-		HLSSegData:    nil,
-		HLSSegName:    "",
-	}
-	self.PutToSrcVideoChan(chunk)
-	return nil
-}
-
-func (self *Stream) WriteTrailer() error {
-	glog.V(logger.Info).Infof("Write Trailer")
-	chunk := &VideoChunk{
-		ID:            EOFStreamMsgID,
-		Seq:           0,
-		HeaderStreams: nil,
-		Packet:        av.Packet{},
-		M3U8:          nil,
-		HLSSegData:    nil,
-		HLSSegName:    "",
-	}
-	self.PutToSrcVideoChan(chunk)
-
-	return nil
-}
-
-func (self *Stream) Close() error {
-	glog.V(logger.Info).Infof("Close")
-	return nil
-}
-
-func (self *Stream) ReadPacket() (av.Packet, error) {
-	glog.V(logger.Info).Infof("Read Packet")
-	return av.Packet{}, errors.New("Not Implmented")
-}
-
-func (self *Stream) Streams() ([]av.CodecData, error) {
-	glog.V(logger.Info).Infof("Streams")
-	return nil, errors.New("Not Implmented")
-}
-
-func (self *Stream) WritePlaylist(pl m3u8.MediaPlaylist) error {
-	chunk := &VideoChunk{
-		ID:            DeliverStreamMsgID,
-		Seq:           0,
-		HeaderStreams: nil,
-		Packet:        av.Packet{},
-		M3U8:          pl.Encode().Bytes(),
-		HLSSegData:    nil,
-		HLSSegName:    "",
-	}
-	self.PutToSrcVideoChan(chunk)
-
-	return nil
-}
-
-func (self *Stream) WriteSegment(name string, s []byte) error {
-	chunk := &VideoChunk{
-		ID:            DeliverStreamMsgID,
-		Seq:           0,
-		HeaderStreams: nil,
-		Packet:        av.Packet{},
-		M3U8:          nil,
-		HLSSegData:    s,
-		HLSSegName:    name,
-	}
-	self.PutToSrcVideoChan(chunk)
-	return nil
-}
-
 // The streamer brookers the video streams
 type Streamer struct {
-	Streams        map[StreamID]*Stream
+	// Streams        map[StreamID]*Stream
 	networkStreams map[StreamID]*lpmsStream.VideoStream
 	subscribers    map[StreamID]*lpmsStream.StreamSubscriber
 	cancellation   map[StreamID]context.CancelFunc
-	hlsBuffers     map[StreamID]lpmsStream.HLSMuxer
-	rtmpBuffers    map[StreamID]*pubsub.Queue
 	SelfAddress    common.Hash
 }
 
 func NewStreamer(selfAddress common.Hash) (*Streamer, error) {
 	glog.Infof("Setting up new streamer with self address: %x", selfAddress[:])
 	s := &Streamer{
-		Streams:        make(map[StreamID]*Stream),
+		// Streams:        make(map[StreamID]*Stream),
 		networkStreams: make(map[StreamID]*lpmsStream.VideoStream),
 		subscribers:    make(map[StreamID]*lpmsStream.StreamSubscriber),
 		cancellation:   make(map[StreamID]context.CancelFunc),
-		hlsBuffers:     make(map[StreamID]lpmsStream.HLSMuxer),
-		rtmpBuffers:    make(map[StreamID]*pubsub.Queue),
 		SelfAddress:    selfAddress,
 	}
 	return s, nil
 }
 
 func (self *Streamer) GetRTMPBuffer(id string) (buf av.Demuxer) {
-	q := self.rtmpBuffers[StreamID(id)]
+	// q := self.rtmpBuffers[StreamID(id)]
+	mux := self.subscribers[StreamID(id)].GetRTMPBuffer(id)
+	q, ok := mux.(*pubsub.Queue)
+	if !ok {
+		return nil
+	}
 	if q != nil {
 		buf = q.Oldest()
 	}
 	return
-}
-
-func (self *Streamer) GetAllRTMPBufferIDs() []StreamID {
-	ids := make([]StreamID, 0, len(self.rtmpBuffers))
-	for k, _ := range self.rtmpBuffers {
-		ids = append(ids, k)
-	}
-
-	return ids
 }
 
 //Subscribes to a RTMP stream.  This function should be called in combination with forwarder.stream(), or another mechanism that will
@@ -272,17 +122,12 @@ func (self *Streamer) EndRTMPStream(strmID string) {
 	}
 }
 
-func (self *Streamer) GetHLSMuxer(id string) (mux lpmsStream.HLSMuxer) {
-	return self.hlsBuffers[StreamID(id)]
-}
-
-func (self *Streamer) GetAllHLSMuxerIDs() []StreamID {
-	ids := make([]StreamID, 0, len(self.hlsBuffers))
-	for k, _ := range self.hlsBuffers {
-		ids = append(ids, k)
+func (self *Streamer) GetHLSMuxer(strmID string, subID string) (mux lpmsStream.HLSMuxer) {
+	sub := self.subscribers[StreamID(strmID)]
+	if sub != nil {
+		return sub.GetHLSMuxer(subID)
 	}
-
-	return ids
+	return nil
 }
 
 func (self *Streamer) SubscribeToHLSStream(strmID string, subID string, mux lpmsStream.HLSMuxer) error {
@@ -301,7 +146,6 @@ func (self *Streamer) SubscribeToHLSStream(strmID string, subID string, mux lpms
 		self.cancellation[StreamID(strmID)] = cancel
 	}
 
-	self.hlsBuffers[StreamID(strmID)] = mux
 	return sub.SubscribeHLS(subID, mux)
 }
 
@@ -316,7 +160,11 @@ func (self *Streamer) UnsubscribeToHLSStream(strmID string, subID string) {
 	if !sub.HasSubscribers() {
 		self.cancellation[StreamID(strmID)]() //Call cancel on hls worker
 		delete(self.subscribers, StreamID(strmID))
-		delete(self.networkStreams, StreamID(strmID))
+		sid := StreamID(strmID)
+		nID, _ := sid.SplitComponents()
+		if self.SelfAddress != nID { //Only delete the networkStream if you are a relay node
+			delete(self.networkStreams, StreamID(strmID))
+		}
 	}
 }
 
@@ -343,34 +191,6 @@ func (self *Streamer) HasSubscribers(strmID string) bool {
 	return false
 }
 
-// func (self *Streamer) SubscribeToHLSStream(ctx context.Context, strmID string, subID string) (buf *lpmsStream.HLSBuffer, err error) {
-// 	buf = self.hlsBuffers[StreamID(strmID)]
-// 	if buf != nil {
-// 		return buf, nil
-// 	}
-
-// 	strm := self.networkStreams[StreamID(strmID)]
-// 	if strm == nil {
-// 		strm = lpmsStream.NewVideoStream(strmID)
-// 		self.networkStreams[StreamID(strmID)] = strm
-// 	}
-
-// 	sub := self.subscribers[StreamID(strmID)]
-// 	if sub == nil {
-// 		sub = lpmsStream.NewStreamSubscriber(strm)
-// 		self.subscribers[StreamID(strmID)] = sub
-// 		go sub.StartHLSWorker(ctx)
-// 	}
-
-// 	buf = lpmsStream.NewHLSBuffer()
-// 	sub.SubscribeHLS(subID, buf)
-
-// 	// self.hlsBuffers[StreamID(id)] = buf
-// 	// go strm.ReadHLSFromStream(ctx, buf)
-
-// 	return
-// }
-
 func (self *Streamer) GetNetworkStream(id StreamID) *lpmsStream.VideoStream {
 	return self.networkStreams[id]
 }
@@ -381,12 +201,6 @@ func (self *Streamer) GetAllNetworkStreams() []*lpmsStream.VideoStream {
 		streams = append(streams, s)
 	}
 	return streams
-}
-
-func (self *Streamer) SubscribeToStream(id string) (stream *Stream, err error) {
-	streamID := StreamID(id) //MakeStreamID(nodeID, id)
-	glog.V(logger.Info).Infof("Subscribing to stream with ID: %v", streamID)
-	return self.saveStreamForId(streamID)
 }
 
 func (self *Streamer) AddNewNetworkStream(format lpmsStream.VideoFormat) (strm *lpmsStream.VideoStream, err error) {
@@ -404,58 +218,20 @@ func (self *Streamer) DeleteNetworkStream(streamID StreamID) {
 	delete(self.networkStreams, streamID)
 }
 
-func (self *Streamer) AddNewStream() (stream *Stream, err error) {
-	//newID := // Generate random string for the stream
-	uid := RandomStreamID()
-	streamID := MakeStreamID(self.SelfAddress, fmt.Sprintf("%x", uid))
-	glog.V(logger.Info).Infof("Adding new stream with ID: %v", streamID)
-	return self.saveStreamForId(streamID)
-}
-
-func (self *Streamer) saveStreamForId(streamID StreamID) (stream *Stream, err error) {
-	if self.Streams[streamID] != nil {
-		return nil, errors.New("Stream with this ID already exists")
+func (self *Streamer) CurrentStatus() string {
+	var networkStreams []string
+	for k := range self.networkStreams {
+		networkStreams = append(networkStreams, k.String())
 	}
 
-	stream = &Stream{
-		SrcVideoChan:  make(chan *VideoChunk, 10),
-		DstVideoChan:  make(chan *VideoChunk, 10),
-		M3U8Chan:      make(chan []byte),
-		HlsSegChan:    make(chan HlsSegment),
-		HlsSegNameMap: make(map[string][]byte),
-		CloseChan:     make(chan bool),
-		ID:            streamID,
+	var subscribers []string
+	for k, v := range self.subscribers {
+		hls := v.HLSSubscribers()
+		rtmp := v.RTMPSubscribers()
+		subscribers = append(subscribers, fmt.Sprintf("\n%v:\n%v hls: %v\n%v rtmp: %v\n\n", k.String(), len(hls), hls, len(rtmp), rtmp))
 	}
-	self.Streams[streamID] = stream
-	go func() {
-		select {
-		case <-stream.CloseChan:
-			self.DeleteStream(stream.ID)
-		}
-	}()
 
-	return stream, nil
-}
-
-func (self *Streamer) GetStream(nodeID common.Hash, id string) (stream *Stream, err error) {
-	// TODO, return error if it doesn't exist
-	return self.Streams[MakeStreamID(nodeID, id)], nil
-}
-
-func (self *Streamer) GetStreamByStreamID(streamID StreamID) (stream *Stream, err error) {
-	return self.Streams[streamID], nil
-}
-
-func (self *Streamer) GetAllStreams() []StreamID {
-	keys := make([]StreamID, 0, len(self.Streams))
-	for k := range self.Streams {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
-func (self *Streamer) DeleteStream(streamID StreamID) {
-	delete(self.Streams, streamID)
+	return fmt.Sprintf("%v streams: %v\n\n%v subscribers: %v\n\n\n\n", len(networkStreams), networkStreams, len(subscribers), subscribers)
 }
 
 func VideoChunkToByteArr(chunk VideoChunk) []byte {
@@ -487,10 +263,3 @@ func ByteArrInVideoChunk(arr []byte) VideoChunk {
 	}
 	return chunk
 }
-
-// func TestChunkEncoding(chunk VideoChunk) {
-// 	bytes := VideoChunkToByteArr(chunk)
-// 	newChunk := ByteArrInVideoChunk(bytes)
-// 	fmt.Println("chunk: ", chunk)
-// 	fmt.Println("newchunk: ", newChunk)
-// }

--- a/livepeer/streaming/streamer_test.go
+++ b/livepeer/streaming/streamer_test.go
@@ -30,36 +30,6 @@ func TestStreamID(t *testing.T) {
 	}
 }
 
-func TestStreamerRegistry(t *testing.T) {
-	addr := RandomStreamID()
-	streamID := RandomStreamID()
-	streamer, _ := NewStreamer(addr)
-
-	firstStream, _ := streamer.AddNewStream()
-	_, rs := firstStream.ID.SplitComponents()
-
-	if len(streamer.Streams) != 1 {
-		t.Errorf("AddNewStream() didn't add a stream to the streamer")
-	}
-
-	resStream, _ := streamer.GetStream(addr, rs)
-	if resStream != firstStream {
-		t.Errorf("GetStream() didn't return the expected stream")
-	}
-
-	// Subscribe to stream
-	sid := MakeStreamID(addr, streamID.Str())
-	_, err := streamer.SubscribeToStream(sid.String())
-	if err != nil {
-		t.Errorf("Got an error subscribing to a new stream. %v", err)
-	}
-
-	_, err = streamer.SubscribeToStream(sid.String())
-	if err == nil {
-		t.Errorf("Didn't get an error subscribing to the same stream twice and should have.")
-	}
-}
-
 func TestNetworkStream(t *testing.T) {
 	addr := RandomStreamID()
 	// streamID := RandomStreamID()

--- a/mediaserver/mediaserver.go
+++ b/mediaserver/mediaserver.go
@@ -83,11 +83,11 @@ func StartLPMS(rtmpPort string, httpPort string, srsRtmpPort string, srsHttpPort
 				// glog.Infof("Found HLS stream:%v locally", strmID)
 			}
 
-			hlsBuffer := streamer.GetHLSMuxer(strmID)
+			subID := "local"
+			hlsBuffer := streamer.GetHLSMuxer(strmID, subID)
 			if hlsBuffer == nil {
 				glog.Infof("Creating new HLS buffer")
 				hlsBuffer = lpmsStream.NewHLSBuffer(HLSBufferCap)
-				subID := "local"
 				err := streamer.SubscribeToHLSStream(strmID, subID, hlsBuffer)
 				if err != nil {
 					glog.Errorf("Error subscribing to hls stream:%v", reqPath)
@@ -211,7 +211,7 @@ func StartLPMS(rtmpPort string, httpPort string, srsRtmpPort string, srsHttpPort
 			return
 		}
 
-		glog.Info("Created Stream: %v", js)
+		glog.Infof("Created Stream: %s", js)
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(js)
 	})
@@ -260,6 +260,10 @@ func StartLPMS(rtmpPort string, httpPort string, srsRtmpPort string, srsHttpPort
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Write(js)
+	})
+
+	http.HandleFunc("/streamerStatus", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(streamer.CurrentStatus()))
 	})
 
 	fs := http.FileServer(http.Dir("static"))


### PR DESCRIPTION
The bug - when unsubscribing an HLS stream, we should only remove the stream if the node is a relay node.  If the node is a broadcasting node, the stream should be kept in-tact, because other nodes may want to subscribe to it.  (If the node is a relay node, it will ask the network for the stream again).  

Also did some cleanup - we don't need the old notion of stream anymore (replaced with NetworkStream)