### PR TITLE
proposal for a new network broadcast interface

### DIFF
--- a/livepeer/streaming/streaming.go
+++ b/livepeer/streaming/streaming.go
@@ -1,0 +1,25 @@
+package streaming
+
+import "context"
+
+//Broadcaster takes a streamID and a reader, and broadcasts the data to whatever underlining network.
+//Example:
+// s := GetStream("StrmID")
+// b := ppspp.NewBroadcaster("StrmID", s.Metadata())
+// for seqNo, data := range s.Segments() {
+// 	b.Broadcast(seqNo, data)
+// }
+type Broadcaster interface {
+	Broadcast(seqNo uint64, data []byte) error
+}
+
+//Subscriber subscribes to a stream defined by strmID.  It returns a reader that contains the stream.
+//Example:
+//	sub, metadata := ppspp.NewSubscriber("StrmID")
+//	stream := NewStream("StrmID", metadata)
+//	err := sub.Subscribe(context.Background(), func(seqNo uint64, data []byte){
+//		stream.WriteSeg(seqNo, data)
+//	})
+type Subscriber interface {
+	Subscribe(ctx context.Context, f func(seqNo uint64, data []byte)) error
+}

--- a/livepeer/streaming/streaming.go
+++ b/livepeer/streaming/streaming.go
@@ -4,22 +4,31 @@ import "context"
 
 //Broadcaster takes a streamID and a reader, and broadcasts the data to whatever underlining network.
 //Example:
-// s := GetStream("StrmID")
-// b := ppspp.NewBroadcaster("StrmID", s.Metadata())
-// for seqNo, data := range s.Segments() {
-// 	b.Broadcast(seqNo, data)
-// }
+// 	s := GetStream("StrmID")
+// 	b := ppspp.NewBroadcaster("StrmID", s.Metadata())
+// 	for seqNo, data := range s.Segments() {
+// 		b.Broadcast(seqNo, data)
+// 	}
+//	b.Finish()
 type Broadcaster interface {
 	Broadcast(seqNo uint64, data []byte) error
+	Finish() error
 }
 
 //Subscriber subscribes to a stream defined by strmID.  It returns a reader that contains the stream.
-//Example:
+//Example 1:
 //	sub, metadata := ppspp.NewSubscriber("StrmID")
 //	stream := NewStream("StrmID", metadata)
-//	err := sub.Subscribe(context.Background(), func(seqNo uint64, data []byte){
+//	ctx, cancel := context.WithCancel(context.Background()
+//	err := sub.Subscribe(ctx, func(seqNo uint64, data []byte){
 //		stream.WriteSeg(seqNo, data)
 //	})
+//	time.Sleep(time.Second * 5)
+//	cancel()
+//
+//Example 2:
+//	sub.Unsubscribe() //This is the same with calling cancel()
 type Subscriber interface {
 	Subscribe(ctx context.Context, f func(seqNo uint64, data []byte)) error
+	Unsubscribe() error
 }


### PR DESCRIPTION
New interface is for network transport layers.  The livepeer node should be able to easily swap in/out video delivery implementations. 